### PR TITLE
Re-visit fault tolerance and reconnects

### DIFF
--- a/assets/src/live_view.ts
+++ b/assets/src/live_view.ts
@@ -28,29 +28,23 @@ export function connectAndRun(options: LiveViewOptions) {
 }
 
 function doConnectAndRun(options: LiveViewOptions, connectState: ConnectState) {
-  console.log("connecting to socket")
   const socket = new WebSocket(`ws://${options.host}:${options.port}/live`)
-  console.log("connected to socket")
 
   const viewStates = {}
 
   socket.addEventListener("open", () => {
-    console.log("socket open")
     onOpen(socket, connectState, options)
   })
 
   socket.addEventListener("message", (event) => {
-    console.log("socket message")
     onMessage(socket, event, connectState, options, viewStates)
   })
 
   socket.addEventListener("close", () => {
-    console.log("socket close")
     onClose(socket, connectState, options)
   })
 
   socket.addEventListener("error", () => {
-    console.log("socket error")
     onError(socket, connectState, options)
   })
 }

--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -70,3 +70,10 @@ where
     let layer = LiveViewLayer::new(pubsub);
     (routes, layer)
 }
+
+fn spawn_unit<F>(future: F) -> tokio::task::JoinHandle<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(future)
+}

--- a/axum-live-view/src/live_view/embed.rs
+++ b/axum-live-view/src/live_view/embed.rs
@@ -1,4 +1,4 @@
-use super::{wrap_in_live_view_container, LiveView, LiveViewId};
+use super::{wrap_in_live_view_container, LiveView, LiveViewId, MakeLiveView};
 use crate::{
     html::Html,
     pubsub::{Logging, PubSub},
@@ -23,16 +23,18 @@ impl<P> EmbedLiveView<P> {
         }
     }
 
-    pub fn embed<T>(&self, live_view: T) -> Html<T::Message>
+    pub async fn embed<T>(&self, make_live_view: T) -> Html<<T::LiveView as LiveView>::Message>
     where
-        T: LiveView,
+        T: MakeLiveView,
         P: PubSub + Clone,
     {
+        let live_view = make_live_view.make_live_view().await;
         let initial_markup = live_view.render();
         let live_view_id = LiveViewId::new();
-        tokio::spawn(super::lifecycle::run_live_view(
+        crate::spawn_unit(super::lifecycle::run_live_view(
             live_view_id,
             live_view,
+            make_live_view,
             self.pubsub.clone(),
         ));
         wrap_in_live_view_container(live_view_id, initial_markup)

--- a/axum-live-view/src/live_view/embed.rs
+++ b/axum-live-view/src/live_view/embed.rs
@@ -23,7 +23,26 @@ impl<P> EmbedLiveView<P> {
         }
     }
 
-    pub async fn embed<T>(&self, make_live_view: T) -> Html<<T::LiveView as LiveView>::Message>
+    pub fn embed<T>(&self, live_view: T) -> Html<T::Message>
+    where
+        T: LiveView + Clone,
+        P: PubSub + Clone,
+    {
+        let initial_markup = live_view.render();
+        let live_view_id = LiveViewId::new();
+        crate::spawn_unit(super::lifecycle::run_live_view(
+            live_view_id,
+            live_view.clone(),
+            super::Shared::new(live_view),
+            self.pubsub.clone(),
+        ));
+        wrap_in_live_view_container(live_view_id, initial_markup)
+    }
+
+    pub async fn embed_make_liveview<T>(
+        &self,
+        make_live_view: T,
+    ) -> Html<<T::LiveView as LiveView>::Message>
     where
         T: MakeLiveView,
         P: PubSub + Clone,

--- a/axum-live-view/src/live_view/lifecycle.rs
+++ b/axum-live-view/src/live_view/lifecycle.rs
@@ -337,12 +337,14 @@ where
         .context("subscribing to mounted topic")
 }
 
+const MOUNT_TIMEOUT: Duration = Duration::from_secs(60);
+
 async fn wait_for_mount(
     live_view_id: LiveViewId,
     mount_stream: &mut OwnedStream<()>,
 ) -> Result<(), ()> {
     tracing::trace!(?live_view_id, "waiting for live view to be mounted");
-    match timeout(Duration::from_secs(10), mount_stream.next()).await {
+    match timeout(MOUNT_TIMEOUT, mount_stream.next()).await {
         Ok(Some(())) => Ok(()),
         Ok(None) | Err(_) => {
             tracing::warn!("live view task mount timeout expired");

--- a/axum-live-view/src/live_view/lifecycle.rs
+++ b/axum-live-view/src/live_view/lifecycle.rs
@@ -337,7 +337,8 @@ where
         .context("subscribing to mounted topic")
 }
 
-const MOUNT_TIMEOUT: Duration = Duration::from_secs(60);
+// const MOUNT_TIMEOUT: Duration = Duration::from_secs(60);
+const MOUNT_TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn wait_for_mount(
     live_view_id: LiveViewId,
@@ -347,7 +348,7 @@ async fn wait_for_mount(
     match timeout(MOUNT_TIMEOUT, mount_stream.next()).await {
         Ok(Some(())) => Ok(()),
         Ok(None) | Err(_) => {
-            tracing::warn!("live view task mount timeout expired");
+            tracing::debug!("live view task mount timeout expired");
             Err(())
         }
     }

--- a/axum-live-view/src/live_view/mod.rs
+++ b/axum-live-view/src/live_view/mod.rs
@@ -17,6 +17,39 @@ pub use self::{
 };
 
 #[async_trait]
+pub trait MakeLiveView: Send + Sync + 'static {
+    type LiveView: LiveView;
+
+    async fn make_live_view(&self) -> Self::LiveView;
+}
+
+#[derive(Clone, Debug)]
+pub struct Shared<T> {
+    live_view: T,
+}
+
+impl<T> Shared<T> {
+    pub fn new(live_view: T) -> Self
+    where
+        T: LiveView + Clone,
+    {
+        Self { live_view }
+    }
+}
+
+#[async_trait]
+impl<T> MakeLiveView for Shared<T>
+where
+    T: LiveView + Clone,
+{
+    type LiveView = T;
+
+    async fn make_live_view(&self) -> Self::LiveView {
+        self.live_view.clone()
+    }
+}
+
+#[async_trait]
 pub trait LiveView: Sized + Send + Sync + 'static {
     type Message: Serialize + DeserializeOwned + PartialEq + Send + Sync + 'static;
 

--- a/axum-live-view/src/live_view/mod.rs
+++ b/axum-live-view/src/live_view/mod.rs
@@ -88,7 +88,7 @@ pub(super) fn wrap_in_live_view_container<T>(live_view_id: LiveViewId, markup: H
 
 #[derive(Debug, Clone)]
 pub struct Updated<T> {
-    live_view: T,
+    live_view: Option<T>,
     js_commands: Vec<JsCommand>,
     skip_render: bool,
 }
@@ -96,7 +96,15 @@ pub struct Updated<T> {
 impl<T> Updated<T> {
     pub fn new(live_view: T) -> Self {
         Self {
-            live_view,
+            live_view: Some(live_view),
+            js_commands: Default::default(),
+            skip_render: false,
+        }
+    }
+
+    pub(crate) fn panicked() -> Self {
+        Self {
+            live_view: None,
             js_commands: Default::default(),
             skip_render: false,
         }

--- a/axum-live-view/src/pubsub/mod.rs
+++ b/axum-live-view/src/pubsub/mod.rs
@@ -92,7 +92,7 @@ impl<T> PubSub for T where T: PubSubBackend {}
 
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
-pub struct BoxErrorWrapper {
+pub(crate) struct BoxErrorWrapper {
     err: BoxError,
 }
 

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -8,7 +8,9 @@ use axum::{
 };
 use axum_live_view::{
     html, js_command,
-    live_view::{EmbedLiveView, EventData, FormEventData, LiveView, Subscriptions, Updated},
+    live_view::{
+        EmbedLiveView, EventData, FormEventData, LiveView, Shared, Subscriptions, Updated,
+    },
     pubsub::{InProcess, PubSub, Topic},
     Html,
 };
@@ -90,13 +92,14 @@ async fn root(
                 <script src="/bundle.js"></script>
             </head>
             <body>
-                { embed_live_view.embed(list).unit() }
-                { embed_live_view.embed(form).unit() }
+                { embed_live_view.embed(Shared::new(list)).await.unit() }
+                { embed_live_view.embed(Shared::new(form)).await.unit() }
             </body>
         </html>
     }
 }
 
+#[derive(Clone)]
 struct MessagesList {
     messages: Arc<Mutex<Vec<Message>>>,
 }
@@ -136,6 +139,7 @@ impl LiveView for MessagesList {
     }
 }
 
+#[derive(Clone)]
 struct SendMessageForm<P> {
     pubsub: P,
     message: String,

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -8,9 +8,7 @@ use axum::{
 };
 use axum_live_view::{
     html, js_command,
-    live_view::{
-        EmbedLiveView, EventData, FormEventData, LiveView, Shared, Subscriptions, Updated,
-    },
+    live_view::{EmbedLiveView, EventData, FormEventData, LiveView, Subscriptions, Updated},
     pubsub::{InProcess, PubSub, Topic},
     Html,
 };

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -92,8 +92,8 @@ async fn root(
                 <script src="/bundle.js"></script>
             </head>
             <body>
-                { embed_live_view.embed(Shared::new(list)).await.unit() }
-                { embed_live_view.embed(Shared::new(form)).await.unit() }
+                { embed_live_view.embed(list).unit() }
+                { embed_live_view.embed(form).unit() }
             </body>
         </html>
     }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -5,9 +5,7 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-use axum_live_view::{
-    html, live_view::Shared, pubsub::InProcess, EmbedLiveView, EventData, Html, LiveView, Updated,
-};
+use axum_live_view::{html, pubsub::InProcess, EmbedLiveView, EventData, Html, LiveView, Updated};
 use serde::{Deserialize, Serialize};
 use std::{env, net::SocketAddr, path::PathBuf};
 use tower_http::services::ServeFile;

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -53,7 +53,7 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
                 </style>
             </head>
             <body>
-                { embed_live_view.embed(Shared::new(counter)).await }
+                { embed_live_view.embed(counter) }
             </body>
         </html>
     }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -5,7 +5,9 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-use axum_live_view::{html, pubsub::InProcess, EmbedLiveView, EventData, Html, LiveView, Updated};
+use axum_live_view::{
+    html, live_view::Shared, pubsub::InProcess, EmbedLiveView, EventData, Html, LiveView, Updated,
+};
 use serde::{Deserialize, Serialize};
 use std::{env, net::SocketAddr, path::PathBuf};
 use tower_http::services::ServeFile;
@@ -44,15 +46,20 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
         <html>
             <head>
                 <script src="/bundle.js"></script>
+                <style>
+                    r#"
+                    body { background: black; color: white; }
+                    "#
+                </style>
             </head>
             <body>
-                { embed_live_view.embed(counter) }
+                { embed_live_view.embed(Shared::new(counter)).await }
             </body>
         </html>
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Counter {
     count: u64,
 }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -78,6 +78,10 @@ impl LiveView for Counter {
             }
         }
 
+        if self.count >= 10 {
+            panic!();
+        }
+
         Updated::new(self)
     }
 

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_live_view::{
     html,
-    live_view::{EmbedLiveView, EventData, LiveView, Shared, Subscriptions, Updated},
+    live_view::{EmbedLiveView, EventData, LiveView, Subscriptions, Updated},
     pubsub::InProcess,
     Html,
 };

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -51,7 +51,7 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
                 <script src="/bundle.js"></script>
             </head>
             <body>
-                { embed_live_view.embed(Shared::new(form)).await }
+                { embed_live_view.embed(form) }
             </body>
         </html>
     }

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_live_view::{
     html,
-    live_view::{EmbedLiveView, EventData, LiveView, Subscriptions, Updated},
+    live_view::{EmbedLiveView, EventData, LiveView, Shared, Subscriptions, Updated},
     pubsub::InProcess,
     Html,
 };
@@ -51,13 +51,13 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
                 <script src="/bundle.js"></script>
             </head>
             <body>
-                { embed_live_view.embed(form) }
+                { embed_live_view.embed(Shared::new(form)).await }
             </body>
         </html>
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct FormView {
     text_input_value: String,
     textarea_value: String,
@@ -269,7 +269,7 @@ struct ChangedInput {
     input: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct FormValues {
     input: String,
     textarea: String,

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_live_view::{
     html,
-    live_view::{EmbedLiveView, EventData, LiveView, Subscriptions, Updated},
+    live_view::{EmbedLiveView, EventData, LiveView, Shared, Subscriptions, Updated},
     pubsub::InProcess,
     Html,
 };
@@ -49,15 +49,20 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
         <html>
             <head>
                 <script src="/bundle.js"></script>
+                <style>
+                    r#"
+                    body { background: black; color: white; }
+                    "#
+                </style>
             </head>
             <body>
-                { embed_live_view.embed(counter) }
+                { embed_live_view.embed(Shared::new(counter)).await }
             </body>
         </html>
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct View {
     count: u64,
     prev: Option<Msg>,
@@ -124,7 +129,7 @@ struct Data {
     id: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 enum Msg {
     Key(String),
 }

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_live_view::{
     html,
-    live_view::{EmbedLiveView, EventData, LiveView, Shared, Subscriptions, Updated},
+    live_view::{EmbedLiveView, EventData, LiveView, Subscriptions, Updated},
     pubsub::InProcess,
     Html,
 };

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -56,7 +56,7 @@ async fn root(embed_live_view: EmbedLiveView<InProcess>) -> impl IntoResponse {
                 </style>
             </head>
             <body>
-                { embed_live_view.embed(Shared::new(counter)).await }
+                { embed_live_view.embed(counter) }
             </body>
         </html>
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -213,11 +213,7 @@ fn examples_run(opt: ExamplesRun) -> Result {
     cmd.args(&["run", "-p", &format!("example-{}", which)]);
     cmd.env(
         "RUST_LOG",
-        format!(
-            "axum_live_view::ws=trace,axum_live_view::live_view=trace,example_{}=trace",
-            which
-        ),
-        // format!("axum_live_view=debug,example_{}=trace", which),
+        format!("axum_live_view=trace,example_{}=trace", which),
     );
     cmd.status()?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -213,7 +213,11 @@ fn examples_run(opt: ExamplesRun) -> Result {
     cmd.args(&["run", "-p", &format!("example-{}", which)]);
     cmd.env(
         "RUST_LOG",
-        format!("axum_live_view=debug,example_{}=trace", which),
+        format!(
+            "axum_live_view::ws=trace,axum_live_view::live_view=trace,example_{}=trace",
+            which
+        ),
+        // format!("axum_live_view=debug,example_{}=trace", which),
     );
     cmd.status()?;
 


### PR DESCRIPTION
- If the WebSocket connection is closed the browser will keep trying to re-open a new one.
- Removes heart beats since reconnecting to a WebSocket results in `GET /live` being called again, so WebSocket aren't re-used.
- If a WebSocket for a live view task is disconnected the task goes back into "wait for mount state", with a 60 sec timeout after which it closes.
- Thus when the browser reconnects the WebSocket the view will be mounted again. This leads to fewer code paths and less state management on the WebSocket side.
- And if `LiveView::update` panics a fresh new view will be created using the `MakeLiveView` given to the embedder.

Fixes https://github.com/davidpdrsn/axum-live-view/issues/99