### PR TITLE
Move things around

### DIFF
--- a/axum-live-view-macros/src/lib.rs
+++ b/axum-live-view-macros/src/lib.rs
@@ -558,13 +558,13 @@ where
         let mut inside_braces = TokenStream::new();
 
         inside_braces.extend(quote! {
-            let mut html = axum_live_view::html::__private::html();
+            let mut html = axum_live_view::__private::html();
         });
 
         let mut buf = String::new();
         self.0.node_to_tokens(&mut buf, &mut inside_braces);
         inside_braces.extend(quote! {
-            axum_live_view::html::__private::fixed(&mut html, #buf);
+            axum_live_view::__private::fixed(&mut html, #buf);
         });
 
         out.extend(quote! {
@@ -649,12 +649,12 @@ impl NodeToTokens for Attr {
                     ident.node_to_tokens(buf, out);
                     write!(buf, "=");
                     out.extend(quote! {
-                        axum_live_view::html::__private::fixed(&mut html, #buf);
+                        axum_live_view::__private::fixed(&mut html, #buf);
                     });
                     buf.clear();
                     out.extend(quote! {
                         #[allow(unused_braces)]
-                        axum_live_view::html::__private::string(
+                        axum_live_view::__private::string(
                             &mut html,
                             format!("{:?}", #block),
                         );
@@ -679,12 +679,12 @@ impl NodeToTokens for Attr {
                     ident.node_to_tokens(buf, out);
                     write!(buf, "=");
                     out.extend(quote! {
-                        axum_live_view::html::__private::fixed(&mut html, #buf);
+                        axum_live_view::__private::fixed(&mut html, #buf);
                     });
                     buf.clear();
                     out.extend(quote! {
                         #[allow(unused_braces)]
-                        axum_live_view::html::__private::message(
+                        axum_live_view::__private::message(
                             &mut html,
                             #block,
                         );
@@ -720,13 +720,13 @@ impl NodeToTokens for LitStr {
 impl NodeToTokens for Block {
     fn node_to_tokens(&self, buf: &mut String, out: &mut TokenStream) {
         out.extend(quote! {
-            axum_live_view::html::__private::fixed(&mut html, #buf);
+            axum_live_view::__private::fixed(&mut html, #buf);
         });
         buf.clear();
 
         out.extend(quote! {
             #[allow(unused_braces)]
-            axum_live_view::html::__private::string(&mut html, #self);
+            axum_live_view::__private::string(&mut html, #self);
         });
     }
 }
@@ -743,7 +743,7 @@ where
         } = self;
 
         out.extend(quote! {
-            axum_live_view::html::__private::fixed(&mut html, #buf);
+            axum_live_view::__private::fixed(&mut html, #buf);
         });
         buf.clear();
 
@@ -755,9 +755,9 @@ where
                     let else_if = ToTokensViaNodeToTokens(else_if);
                     out.extend(quote! {
                         if #cond {
-                            axum_live_view::html::__private::string(&mut html, #then_tree);
+                            axum_live_view::__private::string(&mut html, #then_tree);
                         } else {
-                            axum_live_view::html::__private::string(&mut html, #else_if);
+                            axum_live_view::__private::string(&mut html, #else_if);
                         }
                     });
                 }
@@ -765,9 +765,9 @@ where
                     let else_ = ToTokensViaNodeToTokens(else_);
                     out.extend(quote! {
                         if #cond {
-                            axum_live_view::html::__private::string(&mut html, #then_tree);
+                            axum_live_view::__private::string(&mut html, #then_tree);
                         } else {
-                            axum_live_view::html::__private::string(&mut html, #else_);
+                            axum_live_view::__private::string(&mut html, #else_);
                         }
                     });
                 }
@@ -775,9 +775,9 @@ where
         } else {
             out.extend(quote! {
                 if #cond {
-                    axum_live_view::html::__private::string(&mut html, #then_tree);
+                    axum_live_view::__private::string(&mut html, #then_tree);
                 } else {
-                    axum_live_view::html::__private::string(&mut html, "");
+                    axum_live_view::__private::string(&mut html, "");
                 }
             });
         }
@@ -789,18 +789,18 @@ impl NodeToTokens for For {
         let Self { pat, expr, tree } = self;
 
         out.extend(quote! {
-            axum_live_view::html::__private::fixed(&mut html, #buf);
+            axum_live_view::__private::fixed(&mut html, #buf);
         });
         buf.clear();
 
         out.extend(quote! {
             let mut __first = true;
             for #pat in #expr {
-                axum_live_view::html::__private::string(&mut html, #tree);
+                axum_live_view::__private::string(&mut html, #tree);
 
                 // add some empty segments so the number of placeholders matches up
                 if !__first {
-                    axum_live_view::html::__private::fixed(&mut html, "");
+                    axum_live_view::__private::fixed(&mut html, "");
                 }
                 __first = false;
             }
@@ -813,7 +813,7 @@ impl NodeToTokens for Match {
         let Match { expr, arms } = self;
 
         out.extend(quote! {
-            axum_live_view::html::__private::fixed(&mut html, #buf);
+            axum_live_view::__private::fixed(&mut html, #buf);
         });
         buf.clear();
 
@@ -822,7 +822,7 @@ impl NodeToTokens for Match {
             .map(|Arm { pat, guard, tree }| {
                 let guard = guard.as_ref().map(|guard| quote! { if #guard });
                 quote! {
-                    #pat #guard => axum_live_view::html::__private::string(&mut html, #tree),
+                    #pat #guard => axum_live_view::__private::string(&mut html, #tree),
                 }
             })
             .collect::<TokenStream>();

--- a/axum-live-view/Cargo.toml
+++ b/axum-live-view/Cargo.toml
@@ -18,6 +18,7 @@ axum = { version = "0.4", features = ["ws"] }
 axum-live-view-macros = { path = "../axum-live-view-macros", version = "0.1" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+http = "0.2"
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/axum-live-view/build.rs
+++ b/axum-live-view/build.rs
@@ -119,7 +119,7 @@ fn live_view_impls() -> TokenStream {
                         &mut self,
                         uri: Uri,
                         request_headers: &HeaderMap,
-                        handle: SelfHandle<Self::Message>,
+                        handle: ViewHandle<Self::Message>,
                     ) -> Result<(), Self::Error> {
                         #mount
                         Ok(())

--- a/axum-live-view/src/extract.rs
+++ b/axum-live-view/src/extract.rs
@@ -1,0 +1,141 @@
+use crate::{
+    html::Html,
+    life_cycle::{process_view_messages, EmbedLiveView, ViewTaskHandle},
+};
+use async_trait::async_trait;
+use axum::{
+    extract::{
+        ws::{self, WebSocket, WebSocketUpgrade},
+        FromRequest, RequestParts,
+    },
+    http::{HeaderMap, Uri},
+    response::{IntoResponse, Response},
+};
+use futures_util::{
+    sink::SinkExt,
+    stream::{StreamExt, TryStreamExt},
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
+
+use self::rejection::LiveViewUpgradeRejection;
+
+#[derive(Debug)]
+pub struct LiveViewUpgrade {
+    inner: LiveViewUpgradeInner,
+}
+
+#[derive(Debug)]
+enum LiveViewUpgradeInner {
+    Http,
+    Ws(Box<(WebSocketUpgrade, Uri, HeaderMap)>),
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for LiveViewUpgrade
+where
+    B: Send,
+{
+    type Rejection = LiveViewUpgradeRejection;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        if let Ok(ws) = WebSocketUpgrade::from_request(req).await {
+            let uri = req.uri().clone();
+            let headers = req.headers().cloned().ok_or_else(|| {
+                LiveViewUpgradeRejection::HeadersAlreadyExtracted(Default::default())
+            })?;
+
+            Ok(Self {
+                inner: LiveViewUpgradeInner::Ws(Box::new((ws, uri, headers))),
+            })
+        } else {
+            Ok(Self {
+                inner: LiveViewUpgradeInner::Http,
+            })
+        }
+    }
+}
+
+impl LiveViewUpgrade {
+    pub fn response<F, M>(self, gather_view: F) -> Response
+    where
+        F: FnOnce(EmbedLiveView<'_, M>) -> Html<M>,
+        M: Serialize + DeserializeOwned + Send + 'static,
+    {
+        let (ws, uri, headers) = match self.inner {
+            LiveViewUpgradeInner::Http => {
+                let embed = EmbedLiveView::noop();
+                return gather_view(embed).into_response();
+            }
+            LiveViewUpgradeInner::Ws(data) => *data,
+        };
+
+        let mut view = None;
+
+        let embed = EmbedLiveView::new(&mut view);
+
+        gather_view(embed);
+
+        let view = if let Some(view) = view {
+            view
+        } else {
+            return ws.on_upgrade(|_| async {}).into_response();
+        };
+
+        ws.on_upgrade(|socket| run_view_on_socket(socket, view, uri, headers))
+            .into_response()
+    }
+}
+
+async fn run_view_on_socket<M>(
+    socket: WebSocket,
+    view: ViewTaskHandle<M>,
+    uri: Uri,
+    headers: HeaderMap,
+) where
+    M: Serialize + DeserializeOwned + Send + 'static,
+{
+    let (write, read) = socket.split();
+
+    let write = write.with(|msg| async move {
+        let encoded_msg = ws::Message::Text(serde_json::to_string(&msg)?);
+        Ok::<_, anyhow::Error>(encoded_msg)
+    });
+    futures_util::pin_mut!(write);
+
+    let read = read
+        .map_err(anyhow::Error::from)
+        .and_then(|msg| async move {
+            if let ws::Message::Text(text) = msg {
+                serde_json::from_str(&text).map_err(Into::into)
+            } else {
+                anyhow::bail!("received message from socket that wasn't text")
+            }
+        });
+    futures_util::pin_mut!(read);
+
+    if let Err(err) = process_view_messages(write, read, view, uri, headers).await {
+        tracing::error!(%err, "encountered while processing socket");
+    }
+}
+
+pub mod rejection {
+    use axum::{
+        extract::rejection::HeadersAlreadyExtracted,
+        response::{IntoResponse, Response},
+    };
+
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum LiveViewUpgradeRejection {
+        HeadersAlreadyExtracted(HeadersAlreadyExtracted),
+    }
+
+    impl IntoResponse for LiveViewUpgradeRejection {
+        fn into_response(self) -> Response {
+            match self {
+                Self::HeadersAlreadyExtracted(inner) => inner.into_response(),
+            }
+        }
+    }
+}

--- a/axum-live-view/src/html.rs
+++ b/axum-live-view/src/html.rs
@@ -1,5 +1,5 @@
-use __private::*;
 use axum::response::IntoResponse;
+use private::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{collections::HashMap, fmt};
@@ -10,12 +10,8 @@ pub struct Html<T> {
     dynamic: Vec<DynamicFragment<T>>,
 }
 
-#[doc(hidden)]
-pub mod __private {
-    //! Private API. Do _not_ use anything from this module!
-
+pub(crate) mod private {
     use super::*;
-    use fmt;
 
     pub fn html<T>() -> Html<T> {
         Html {

--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -39,20 +39,20 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
-#[doc(hidden)]
-pub mod html;
-
 pub mod event_data;
+pub mod extract;
 pub mod js_command;
 pub mod life_cycle;
 pub mod live_view;
 
+mod html;
 mod util;
 
-pub use self::{
-    event_data::EventData,
-    html::Html,
-    life_cycle::{LiveViewUpgrade, SelfHandle},
-    live_view::{LiveView, Updated},
-};
+pub use self::{extract::LiveViewUpgrade, html::Html, live_view::LiveView};
 pub use axum_live_view_macros::html;
+
+#[doc(hidden)]
+pub mod __private {
+    //! Private API. Do _not_ use anything from this module!
+    pub use crate::html::private::*;
+}

--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -42,12 +42,13 @@
 pub mod event_data;
 pub mod extract;
 pub mod js_command;
-pub mod life_cycle;
 pub mod live_view;
 
 mod html;
+mod life_cycle;
 mod util;
 
+#[doc(inline)]
 pub use self::{extract::LiveViewUpgrade, html::Html, live_view::LiveView};
 pub use axum_live_view_macros::html;
 

--- a/axum-live-view/src/live_view/combine.rs
+++ b/axum-live-view/src/live_view/combine.rs
@@ -1,4 +1,6 @@
-use crate::{life_cycle::SelfHandle, EventData, Html, LiveView, Updated};
+use crate::{
+    event_data::EventData, html::Html, life_cycle::SelfHandle, live_view::Updated, LiveView,
+};
 use async_trait::async_trait;
 use axum::http::{HeaderMap, Uri};
 use serde::{Deserialize, Serialize};

--- a/axum-live-view/src/live_view/combine.rs
+++ b/axum-live-view/src/live_view/combine.rs
@@ -1,5 +1,8 @@
 use crate::{
-    event_data::EventData, html::Html, life_cycle::SelfHandle, live_view::Updated, LiveView,
+    event_data::EventData,
+    html::Html,
+    live_view::{Updated, ViewHandle},
+    LiveView,
 };
 use async_trait::async_trait;
 use axum::http::{HeaderMap, Uri};

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -9,8 +9,7 @@ use axum::{
 use axum_live_view::{
     event_data::EventData,
     html, js_command,
-    life_cycle::SelfHandle,
-    live_view::{self, Updated},
+    live_view::{self, Updated, ViewHandle},
     Html, LiveView, LiveViewUpgrade,
 };
 use serde::{Deserialize, Serialize};
@@ -114,7 +113,7 @@ impl LiveView for MessagesList {
         &mut self,
         _: Uri,
         _: &HeaderMap,
-        handle: SelfHandle<Self::Message>,
+        handle: ViewHandle<Self::Message>,
     ) -> Result<(), Self::Error> {
         let mut rx = self.tx.subscribe();
         tokio::spawn(async move {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -7,7 +7,11 @@ use axum::{
     AddExtensionLayer, Router,
 };
 use axum_live_view::{
-    html, js_command, live_view, EventData, Html, LiveView, LiveViewUpgrade, SelfHandle, Updated,
+    event_data::EventData,
+    html, js_command,
+    life_cycle::SelfHandle,
+    live_view::{self, Updated},
+    Html, LiveView, LiveViewUpgrade,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -26,18 +30,6 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let messages: Messages = Default::default();
-
-    // {
-    //     let pubsub = pubsub.clone();
-    //     let messages = messages.clone();
-    //     let mut new_messages = pubsub.subscribe(&NewMessageTopic).await.unwrap();
-    //     tokio::spawn(async move {
-    //         while let Some(Json(msg)) = new_messages.next().await {
-    //             messages.lock().unwrap().push(msg);
-    //             let _ = pubsub.broadcast(&ReRenderMessageList, ()).await;
-    //         }
-    //     });
-    // }
 
     let (tx, _) = broadcast::channel::<NewMessagePing>(1024);
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -5,7 +5,9 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-use axum_live_view::{html, EventData, Html, LiveView, LiveViewUpgrade, Updated};
+use axum_live_view::{
+    event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
+};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, env, net::SocketAddr, path::PathBuf};
 use tower_http::services::ServeFile;

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -5,7 +5,9 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-use axum_live_view::{html, EventData, Html, LiveView, LiveViewUpgrade, Updated};
+use axum_live_view::{
+    event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
+};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::Infallible, env, net::SocketAddr, path::PathBuf};
 use tower_http::services::ServeFile;

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -5,7 +5,9 @@ use axum::{
     routing::{get, get_service},
     Router,
 };
-use axum_live_view::{html, EventData, Html, LiveView, LiveViewUpgrade, Updated};
+use axum_live_view::{
+    event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
+};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, env, net::SocketAddr, path::PathBuf};
 use tower_http::services::ServeFile;


### PR DESCRIPTION
Cleans up the module boundaries a bit and makes the generated docs more approachable.