### PR TITLE
Add route with precompiled JavaScript

### DIFF
--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -39,6 +39,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
+use axum::{http::header, response::Headers, routing::get, Router};
+
 #[macro_use]
 mod macros;
 
@@ -59,6 +61,23 @@ pub use axum_live_view_macros::html;
 #[cfg(feature = "precompiled-js")]
 #[cfg_attr(docsrs, doc(cfg(feature = "precompiled-js")))]
 pub const PRECOMPILED_JS: &str = include_str!("../../assets/axum_live_view.min.js");
+
+#[cfg(feature = "precompiled-js")]
+#[cfg_attr(docsrs, doc(cfg(feature = "precompiled-js")))]
+pub fn precompiled_js_route<B>(path: &str) -> Router<B>
+where
+    B: Send + 'static,
+{
+    Router::new().route(
+        path,
+        get(|| async {
+            (
+                Headers([(header::CONTENT_TYPE, "application/json")]),
+                PRECOMPILED_JS,
+            )
+        }),
+    )
+}
 
 #[doc(hidden)]
 pub mod __private {


### PR DESCRIPTION
So users just have to do

```rust
routes.merge(axum_live_view::precompiled_js_route("app.js"))
```