### PR TITLE
Examples cleanup

### DIFF
--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
-axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
+axum = "0.6"
+axum-live-view = { path = "../../axum-live-view", version = "0.1", features = [
+  "precompiled-js",
+] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
@@ -14,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 tower = "0.4"
 serde_json = "1.0"
 futures-util = "0.3"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.3", features = ["fs"] }

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -13,7 +13,6 @@ use axum_live_view::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    convert::Infallible,
     net::SocketAddr,
     sync::{Arc, Mutex},
 };

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
-axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
+axum = "0.6"
+axum-live-view = { path = "../../axum-live-view", version = "0.1", features = [
+  "precompiled-js",
+] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tower-http = { version = "0.2", features = ["fs"] }
-time = { version = "0.3.5", features = ["local-offset", "formatting"] }
+tower-http = { version = "0.3", features = ["fs"] }
+time = { version = "0.3", features = ["local-offset", "formatting"] }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,8 +1,8 @@
-use axum::{async_trait, response::IntoResponse, routing::get, Router};
+use axum::{response::IntoResponse, routing::get, Router};
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
-use std::{convert::Infallible, net::SocketAddr};
+use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
-axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
+axum = "0.6"
+axum-live-view = { path = "../../axum-live-view", version = "0.1", features = [
+  "precompiled-js",
+] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.3", features = ["fs"] }

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
-axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
+axum = "0.6"
+axum-live-view = { path = "../../axum-live-view", version = "0.1", features = [
+  "precompiled-js",
+] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.3", features = ["fs"] }

--- a/examples/key-events/Cargo.toml
+++ b/examples/key-events/Cargo.toml
@@ -5,11 +5,13 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
-axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
+axum = "0.6"
+axum-live-view = { path = "../../axum-live-view", version = "0.1", features = [
+  "precompiled-js",
+] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.3", features = ["fs"] }

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -1,9 +1,9 @@
-use axum::{async_trait, response::IntoResponse, routing::get, Router};
+use axum::{response::IntoResponse, routing::get, Router};
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, net::SocketAddr};
+use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Btw, why does each example have it's own folder? There's nothing except `main.rs` there. Maybe we just put the binaries into the example folder? The deps would be easier to update and `cargo check --examples` would work.